### PR TITLE
fix: Replace distrobox-enter cmd with apx

### DIFF
--- a/modules/00-vanilla-apx.yml
+++ b/modules/00-vanilla-apx.yml
@@ -18,6 +18,7 @@ modules:
   - mkdir -p /usr/share/apx
   - cp -r /sources/distrobox-1.6.0.1 /usr/share/apx/distrobox
   - chmod +x /usr/share/apx/distrobox/distrobox*
+  - sed -E -i 's/distrobox enter %s/apx %s enter/' /usr/share/apx/distrobox/distrobox-create
 - name: apx-manpage
   type: shell
   source:


### PR DESCRIPTION
Replaces the `distrobox enter` message shown after creating a container for `apx enter`