### PR TITLE
feat: add syscall-interceptor

### DIFF
--- a/includes.container/ld.so.preload
+++ b/includes.container/ld.so.preload
@@ -1,0 +1,1 @@
+/usr/lib/libsyscall_interceptor.so

--- a/includes.container/syscall_config.yml
+++ b/includes.container/syscall_config.yml
@@ -1,0 +1,83 @@
+log_file: /dev/null
+syscalls:
+  - fsmount:
+      log: false
+      block: true
+      arg0:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: true
+  - mount:
+      log: false
+      block: true
+      arg1:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: false
+  - mount:
+      log: false
+      block: true
+      arg0:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: false
+  - mount_setattr:
+      log: false
+      block: true
+      arg0:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: true
+  - mount_setattr:
+      log: false
+      block: true
+      arg1:
+        content: "/usr"
+        matchtype: "contains"
+        ischar: true
+        isFdesc: false
+  - move_mount:
+      log: false
+      block: true
+      arg0:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: true
+  - move_mount:
+      log: false
+      block: true
+      arg1:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: false
+  - move_mount:
+      log: false
+      block: true
+      arg2:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: true
+  - move_mount:
+      log: false
+      block: true
+      arg3:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: false
+  - umount2:
+      log: false
+      block: true
+      arg0:
+        content: "/usr"
+        matchtype: "contains"
+        isChar: true
+        isFdesc: false
+

--- a/modules/03-syscall_interceptor.yml
+++ b/modules/03-syscall_interceptor.yml
@@ -1,0 +1,44 @@
+name: syscall_interceptor
+type: shell
+commands:
+  - cd /sources/syscall-interceptor-1.1-1/
+  - autoreconf --install
+  - cp /syscall_config.yml ./config.yml
+  - ./configure
+  - make
+  - cp src/.libs/libsyscall_interceptor.so /usr/lib/
+  - rm /syscall_config.yml
+source:
+  type: tar
+  url: https://github.com/linux-immutability-tools/syscall-interceptor/archive/refs/tags/v1.1-1.tar.gz
+  checksum: a59dfec4909ffbdf51327ca3b44b9d04298670e9af75dc3652b5b234076ddd89
+modules:
+  - name: package_deps
+    type: apt
+    source:
+      packages:
+        - python3-yaml
+        - libcapstone-dev
+        - gcc
+        - cmake
+        - make
+        - pkg-config
+        - autoconf
+        - automake
+        - autotools-dev
+        - libtool
+  - name: syscall_intercept
+    type: shell
+    commands:
+      - cd /sources/syscall_intercept
+      - mkdir build
+      - cd build
+      - cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc
+      - make
+      - make install
+    source:
+      type: git
+      url: https://github.com/pmem/syscall_intercept
+      branch: "master"
+      commit: ca4b13531f883597c2f04a40e095f76f6c3a6d22
+

--- a/recipe.yml
+++ b/recipe.yml
@@ -25,6 +25,7 @@ modules:
     - modules/00-vanilla-apx-stacks
     - modules/00-vanilla-ikaros
     - modules/03-fswarn
+    - modules/03-syscall_interceptor
     - modules/05-firmware
     - modules/10-input-and-locale
     - modules/20-ssh
@@ -53,6 +54,7 @@ modules:
 - name: cleanup1
   type: shell
   commands:
+  - mv /ld.so.preload /etc/ld.so.preload
   - apt remove -y linux-image-rt-amd64 linux-image-6.4.0-4-rt-amd64
   - apt remove -y dpkg-dev build-essential
   - apt autoremove -y


### PR DESCRIPTION
Adds [syscall-interceptor](https://github.com/linux-immutability-tools/syscall-interceptor) according to https://github.com/Vanilla-OS/security/issues/3

The configuration currently blocks all available mount related syscalls (`fsmount`, `mount`, `move_mount` and `umount2`) that have `/usr` as the target and/or source