### PR TITLE
Configures grub to be used by abroot

### DIFF
--- a/includes.container/etc/default/grub
+++ b/includes.container/etc/default/grub
@@ -1,0 +1,14 @@
+# If you change this file, run 'abroot upgrade -f' afterwards to apply the settings
+
+GRUB_DEFAULT=0
+GRUB_TIMEOUT=0
+GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
+GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+GRUB_CMDLINE_LINUX=""
+ 
+# If your computer has multiple operating systems installed, then you
+# probably want to run os-prober. However, if your computer is a host
+# for guest OSes installed via LVM or raw disk devices, running
+# os-prober can cause damage to those guest OSes as it mounts
+# filesystems to look for things.
+GRUB_DISABLE_OS_PROBER=true

--- a/includes.container/etc/grub.d/10_vanilla
+++ b/includes.container/etc/grub.d/10_vanilla
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# vanilla os entry, don't change the REPLACED_BY_ABROOT placeholder
+cat << EOF
+menuentry "Vanilla OS" --class gnu-linux --class gnu --class os {
+  insmod gzio
+  insmod part_gpt
+  insmod ext2
+REPLACED_BY_ABROOT
+}
+EOF

--- a/includes.container/etc/grub.d/31_os_prober_cleanup
+++ b/includes.container/etc/grub.d/31_os_prober_cleanup
@@ -1,0 +1,6 @@
+#!/bin/sh
+# 30_os-prober in chroot fails to unmount this directory
+
+set +e
+umount -R /var/lib/os-prober/mount/
+set -e

--- a/modules/999-remove-grub-files.yml
+++ b/modules/999-remove-grub-files.yml
@@ -1,0 +1,6 @@
+name: remove-grub-files
+type: shell
+commands:
+- rm /etc/grub.d/05_debian_theme
+- rm /etc/grub.d/10_linux
+- rm /etc/grub.d/20_linux_xen

--- a/recipe.yml
+++ b/recipe.yml
@@ -42,6 +42,7 @@ modules:
     - modules/140-manpages
     - modules/998-podman-registry
     - modules/999-replace-locale-gen
+    - modules/999-remove-grub-files
 
 - name: zram-config
   type: shell


### PR DESCRIPTION
This will not change anything until ABRoot actually uses the grub.cfg generated by grub-mkconfig.

When it does, these changes will ensure a clean grub configuration that still allows the user to customize it.

Note:
31_os_prober_cleanup is necessary because the script 30_os-prober fails to unmount the future partition after mounting it. This approach was chosen because modifying 30_os-prober would mean we would have to maintain the script ourselves. 

10_linux and 20_linux_xen try to generate a boot entry which won't work here. They are replaced by 10_vanilla