### PR TITLE
feat: add apt-doc package

### DIFF
--- a/modules/140-manpages.yml
+++ b/modules/140-manpages.yml
@@ -4,3 +4,4 @@ source:
   packages:
   - manpages
   - manpages-posix
+  - apt-doc


### PR DESCRIPTION
Closes #44

----

This small package will provide the manpage for the apt command (and this man page can be accessed from inside the containers after we propagate the config in `/etc`).