### PR TITLE
fix: configure log source for `podman events`

### DIFF
--- a/includes.container/etc/containers/containers.conf
+++ b/includes.container/etc/containers/containers.conf
@@ -1,2 +1,5 @@
 [containers]
-log_driver = "k8s-file"
+log_driver="k8s-file"
+
+[engine]
+events_logger="file"


### PR DESCRIPTION
When we switched the log driver from `journald` to `k8s-file` due to podman being unable to log to the system journal, it broke the events command since it defaults to searching the journal for log entries.

This commit changes the `events_logger` configuration so it searches for events in the correct place.

`podman events` used by apx-gui for monitoring changes to the subsystems.