### PR TITLE
feat: update firmware packages

### DIFF
--- a/modules/05-firmware.yml
+++ b/modules/05-firmware.yml
@@ -1,16 +1,35 @@
-name: input-and-locale
-type: apt
-source:
-  packages:
-  - firmware-linux
-  - firmware-linux-nonfree
-  - firmware-linux-free
-  - firmware-iwlwifi
-  - firmware-realtek
-  - firmware-atheros
-  - intel-microcode
-  - amd64-microcode
-  - b43-fwcutter
-  - firmware-b43-installer
-  - firmware-brcm80211
-  - firmware-sof-signed
+name: divert-originals
+type: shell
+commands:
+  - find /usr/lib/firmware -type f -exec dpkg-divert --add --rename --divert '{}-old' '{}' \;
+modules:
+- name: dependencies
+  type: apt
+  source:
+    packages:
+    - curl
+    - rsync
+- name: install-firmware
+  type: apt
+  source:
+    packages:
+    - firmware-linux
+    - firmware-linux-nonfree
+    - firmware-linux-free
+    - firmware-iwlwifi
+    - firmware-realtek
+    - firmware-atheros
+    - intel-microcode
+    - amd64-microcode
+    - b43-fwcutter
+    - firmware-b43-installer
+    - firmware-brcm80211
+    - firmware-sof-signed
+- name: firmware-update
+  type: shell
+  commands:
+    - curl -O https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/snapshot/linux-firmware-20240513.tar.gz
+    - tar xzf linux-firmware-20240513.tar.gz
+    - rsync -avHAX --existing linux-firmware-20240513/ /usr/lib/firmware/
+    - rm linux-firmware-20240513.tar.gz
+    - rm -rf linux-firmware-20240513

--- a/modules/30-utils.yml
+++ b/modules/30-utils.yml
@@ -4,10 +4,8 @@ source:
   packages:
   - nano
   - zsync
-  - rsync
   - dialog
   - less
-  - curl
   - tracker
   - bash-completion
   - libnss-myhostname


### PR DESCRIPTION
Updates existing firmware to the latest tag in the kernel tree.

I don't think a divert is necessary since we're first installing the regular packages and then overwriting them with rsync, but please correct me if I'm wrong.