### PR TITLE
feat[close #55]: Kernel lockdown via lsm=integrity

### DIFF
--- a/includes.container/etc/abroot/kargs
+++ b/includes.container/etc/abroot/kargs
@@ -1,0 +1,1 @@
+quiet splash bgrt_disable $vt_handoff lsm=integrity


### PR DESCRIPTION
NOTE: This change must be reflected to any image that replaces the /etc/abroot/kargs file (nvidia-image only, here the [PR](https://github.com/Vanilla-OS/nvidia-image/pull/34)) and the vanilla-installer (Here the [PR](https://github.com/Vanilla-OS/vanilla-installer/pull/386) for the installer).

--

Closes #55
Closes https://github.com/Vanilla-OS/security/issues/6