### PR TITLE
fix [#58]: mounts tmp as tmpfs

### DIFF
--- a/includes.container/usr/share/init.d/050-mount-tmp.sh
+++ b/includes.container/usr/share/init.d/050-mount-tmp.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Mounting tmpfs in /tmp"
+mount mount -t tmpfs -o nodev,nosuid,mode=1777 tmpfs /tmp


### PR DESCRIPTION
I tested it and it seems to work without any issues.

Fixes #58 