### PR TITLE
fixes incorrect ordering of init hooks

### DIFF
--- a/includes.container/usr/sbin/init.new
+++ b/includes.container/usr/sbin/init.new
@@ -33,7 +33,7 @@ run_hooks() {
     return
   fi
 
-  hooks=($(find "$path" -type f 2>/dev/null))
+  hooks=($(find "$path" -type f 2>/dev/null | sort))
 
   if [[ ${#hooks[@]} -eq 0 ]]; then
     log "warn" "No hooks found in $path"


### PR DESCRIPTION
find apparently doesn't return sorted data

The data has to be sorted tho to guarantee that the hooks are executed in the correct order