### PR TITLE
fix: Remember polkit auth

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -72,6 +72,11 @@ stages:
     - apt autoremove -y
     - apt clean
 
+  - name: polkit-remember-auth
+    type: shell
+    commands:
+    - sed -ie 's/auth_admin/auth_admin_keep/' /usr/share/polkit-1/actions/org.freedesktop.policykit.policy
+
   - name: fsguard
     type: fsguard
     FsGuardLocation: "/usr/sbin/FsGuard"


### PR DESCRIPTION
This PR modifies the polkit rule for `pkexec` so that it remembers auth for a couple minutes, similar to how `sudo` does.