### PR TITLE
fix [#70]: uses gzip compression for initramfs command

### DIFF
--- a/modules/160-initramfs-compression.yml
+++ b/modules/160-initramfs-compression.yml
@@ -1,0 +1,4 @@
+name: initramfs-compression
+type: shell
+commands:
+  - sed -i 's/COMPRESS=zstd/COMPRESS=gzip/' /etc/initramfs-tools/initramfs.conf

--- a/recipe.yml
+++ b/recipe.yml
@@ -46,6 +46,7 @@ stages:
       - modules/130-kernel.yml
       - modules/140-manpages.yml
       - modules/150-init-executable.yml
+      - modules/160-initramfs-compression.yml
       - modules/998-podman-registry.yml
       - modules/999-replace-locale-gen.yml
       - modules/999-remove-grub-files.yml


### PR DESCRIPTION
I've tried that in the past but it didn't work because we were generating the initramfs in some other way. 
Now it does do the trick.

This should probably be merged into the dev branch, so I will move this PR once the dev branch exists

Fixes #70 