### PR TITLE
feat: add libasound2 to core image

### DIFF
--- a/modules/60-sound.yml
+++ b/modules/60-sound.yml
@@ -7,3 +7,4 @@ source:
   - wireplumber
   - alsa-utils
   - alsa-firmware-loaders
+  - libasound2t64


### PR DESCRIPTION
This will help with apps that require libasound2 but dont explicitly depend on it