### PR TITLE
Set proper name for 05-firmware.yml

### DIFF
--- a/modules/05-firmware.yml
+++ b/modules/05-firmware.yml
@@ -1,4 +1,4 @@
-name: input-and-locale
+name: firmware
 type: apt
 source:
   packages:


### PR DESCRIPTION
05-firmware.yml had the name `input-and-locale`, even though it should be `firmware`