### PR TITLE
fix[close #73]: (dev) iptables missing breaking abroot

### DIFF
--- a/modules/91-iptables.yml
+++ b/modules/91-iptables.yml
@@ -1,4 +1,10 @@
-name: enable-iptables-systemd-unit
-type: shell
-commands:
-  - ln -s /usr/lib/systemd/system/iptables.service /etc/systemd/system/multi-user.target.wants/iptables.service
+name: iptables
+type: apt
+source:
+  packages:
+  - iptables
+modules:
+  - name: enable-iptables-systemd-unit
+    type: shell
+    commands:
+      - ln -s /usr/lib/systemd/system/iptables.service /etc/systemd/system/multi-user.target.wants/iptables.service


### PR DESCRIPTION
iptables was not being explicitly requested but was marked as installed, even with the binary not being placed in /usr/sbin or /usr/bin. By manually installing it via the umount/lpkg/apt process, fixes the issue.

This PR ensures it gets requested.