### PR TITLE
ci: remove base check in favor of tags

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -24,28 +24,9 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
-  check_base_status:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Clone base image
-      if: ${{ github.ref_type == 'tag' }}
-      uses: actions/checkout@v4
-      with:
-        repository: Vanilla-OS/pico-image
-
-    - name: Check if the base is up to date
-      if: ${{ github.ref_type == 'tag' }}
-      run: |
-        git fetch origin
-        main_head=$( git rev-parse origin/main )
-        dev_head=$( git rev-parse origin/dev )
-        echo main branch is at: $main_head
-        echo dev branch is at: $dev_head
-        [ "$main_head" = "$dev_head" ]
-
   build:
     runs-on: ubuntu-latest
-    needs: [verify-image, check_base_status]
+    needs: [verify-image]
     permissions:
       contents: write # Allow actions to create release
       packages: write # Allow pushing images to GHCR


### PR DESCRIPTION
Since we tag releases from dev directly, we can simply remove the base check and stop merging dev into main.