### PR TITLE
fix [#87]: adds grub-mkconfig script that deletes itself

### DIFF
--- a/includes.container/usr/sbin/grub-mkconfig-replacement
+++ b/includes.container/usr/sbin/grub-mkconfig-replacement
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+/usr/libexec/grub-mkconfig "$@"
+# delete this script so users don't accidentally break their system with it
+rm /usr/sbin/grub-mkconfig

--- a/includes.container/usr/sbin/update-grub-replacement
+++ b/includes.container/usr/sbin/update-grub-replacement
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo please use abroot to update the grub configuration
+exit 1

--- a/modules/41-move-boot-scripts.yml
+++ b/modules/41-move-boot-scripts.yml
@@ -1,0 +1,11 @@
+name: move-boot-scripts
+type: shell
+commands:
+  - mkdir -p /usr/libexec/
+  - mv /usr/sbin/grub-mkconfig /usr/libexec/
+  - mv /usr/sbin/grub-mkconfig-replacement /usr/sbin/grub-mkconfig
+  - chmod +x /usr/sbin/grub-mkconfig
+  - mv /usr/sbin/update-grub /usr/libexec/
+  - mv /usr/sbin/update-grub-replacement /usr/sbin/update-grub
+  - chmod +x /usr/sbin/update-grub
+  

--- a/recipe.yml
+++ b/recipe.yml
@@ -35,6 +35,7 @@ stages:
       - modules/20-ssh.yml
       - modules/30-utils.yml
       - modules/40-essentials.yml
+      - modules/41-move-boot-scripts.yml
       - modules/50-fs.yml
       - modules/60-sound.yml
       - modules/70-compression.yml


### PR DESCRIPTION
The grub-mkconfig command will be used by abroot and then deletes itself.

This is to prevent users from running this script, since that would brick their system.

Fixes #87 

