### PR TITLE
fix: remove automatically generated ssh key

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -91,6 +91,7 @@ stages:
   - name: cleanup2
     type: shell
     commands:
+      - rm -rf /etc/sshd/ssh_host_rsa_key
       - rm -rf /var/cache/*
       - rm -rf /tmp/*
       - rm -rf /var/tmp/*


### PR DESCRIPTION
Removes the host ssh key generated by an apt hook