### PR TITLE
Update /etc/skel/.bashrc to expand $HOME path

### DIFF
--- a/includes.container/etc/skel/.bashrc
+++ b/includes.container/etc/skel/.bashrc
@@ -84,9 +84,9 @@ if [ -x /usr/bin/dircolors ]; then
     alias ls='ls --color=auto'
 fi
 
-# extend $PATH to read from ~/.local/bin so the user finds their
-# own binaries
-export PATH="~/.local/bin":$PATH
+# Prepend ~/.local/bin to the PATH in order to give precedence to user-installed
+# executables.
+export PATH="$HOME/.local/bin:$PATH"
 
 # !!! LOOKING FOR CUSTOM ALIASES? !!!
 # You may want to put all your additions into a separate file like


### PR DESCRIPTION
See https://stackoverflow.com/questions/44704710/tilde-char-in-path-e-g-path-bin-usr-bin-bin/44704799#44704799

Non-sh utilities cannot expand ~ in a string.