### PR TITLE
Configure iptables for IPv6, closes #97

### DIFF
--- a/includes.container/etc/iptables/rules.v6
+++ b/includes.container/etc/iptables/rules.v6
@@ -1,0 +1,15 @@
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+
+# Allow loopback
+-A INPUT -i lo -j ACCEPT
+
+# Allow SSH (Port 22)
+# -A INPUT -p tcp --dport 22 -j ACCEPT
+
+# Allow enstabilished and related connections
+-A INPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+COMMIT

--- a/includes.container/usr/systemd/system/ip6tables.service
+++ b/includes.container/usr/systemd/system/ip6tables.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=ip6tables firewall rules
+DefaultDependencies=no
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/ip6tables-restore /etc/iptables/rules.v6
+ExecReload=/sbin/ip6tables-restore /etc/iptables/rules.v6
+ExecStop=/sbin/ip6tables-save > /etc/iptables/rules.v6
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/modules/91-iptables.yml
+++ b/modules/91-iptables.yml
@@ -8,3 +8,7 @@ modules:
     type: shell
     commands:
       - ln -s /usr/lib/systemd/system/iptables.service /etc/systemd/system/multi-user.target.wants/iptables.service
+  - name: enable-ip6tables-systemd-unit
+    type: shell
+    commands:
+      - ln -s /usr/lib/systemd/system/ip6tables.service /etc/systemd/system/multi-user.target.wants/ip6tables.service


### PR DESCRIPTION
The iptables firewall configuration for IPv6 was missing from the base image.

In theory, the same configuration works for both, it just needs to sit in an IPv6 specific configuration.

Closes #97.