### PR TITLE
pin kernel version

### DIFF
--- a/modules/01-kernel.yml
+++ b/modules/01-kernel.yml
@@ -2,5 +2,7 @@ name: kernel
 type: apt
 source:
   packages:
-  - linux-image-amd64
-  - linux-headers-amd64
+  - linux-image-6.12.9-amd64
+  # removed temporarily to avoid changing kernel version
+  # - linux-image-amd64
+  # - linux-headers-amd64

--- a/modules/90-network.yml
+++ b/modules/90-network.yml
@@ -13,7 +13,8 @@ source:
   - modemmanager
   - wpasupplicant
   - wireless-tools
-  - wireguard
+  # removed temporarily to avoid changing kernel version 
+  # - wireguard
   - avahi-autoipd
   - avahi-daemon
   - rfkill


### PR DESCRIPTION
This is needed since upgrading the kernel currently breaks existing installs.