### PR TITLE
fix: replace deprecated ntp package with chrony

### DIFF
--- a/modules/90-network.yml
+++ b/modules/90-network.yml
@@ -22,5 +22,5 @@ source:
   - libspa-0.2-bluetooth
   - libnss-mdns
   - libproxy1-plugin-networkmanager
-  - ntp
+  - chrony
   - iputils-ping


### PR DESCRIPTION
This PR removes the deprecated and now unavailable `ntp` package (in the latest testing repo sync)  and replaces it with `chrony`.

With Debian 12 Bookworm release, Debian has replaced the deprecated `ntp` package with `ntpsec` (which seems to have trimmed down a few features to be minimal).

But for our usage similar to Ubuntu and Fedora, I think shipping `chrony` by default would be ideal since we have images like `vm` which runs under an hypervisor and this package is also versatile, uses advanced algorithms making it less susceptible to exploits that was present in the original one.

## Problem

![image](https://github.com/user-attachments/assets/a12d8840-828c-416f-8d21-2726a1f31b43)

https://github.com/Vanilla-OS/core-image/actions/runs/13671795839/job/38223444901#step:12:5622

## References

1. https://documentation.ubuntu.com/server/how-to/networking/serve-ntp-with-chrony/index.html
2. https://community.ntppool.org/t/chrony-vs-ntpsec-vs-ntp-ntpd/3193
3. https://packages.debian.org/sid/chrony


