### PR TITLE
adds distrobox

### DIFF
--- a/modules/30-utils.yml
+++ b/modules/30-utils.yml
@@ -11,3 +11,4 @@ source:
   - tracker
   - bash-completion
   - libnss-myhostname
+  - distrobox


### PR DESCRIPTION
Apx won't cover every use case that distrobox can. Installing it by default will be helpful for a lot of users.