### PR TITLE
Upgrade to Vib 1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ jobs:
         run: |
           sed 's/ghcr.io\/vanilla-os\/pico:dev/ghcr.io\/vanilla-os\/pico:main/' -i recipe.yml
 
-      - uses: vanilla-os/vib-gh-action@v0.8.1
+      - uses: vanilla-os/vib-gh-action@v1.0.2
         with:
             recipe: 'recipe.yml'
-            plugins: 'Vanilla-OS/vib-fsguard:v1.5.3'
+            plugins: 'Vanilla-OS/vib-fsguard:v1.6.0'
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -41,10 +41,10 @@ jobs:
       run: |
         sed 's/ghcr.io\/vanilla-os\/pico:dev/ghcr.io\/vanilla-os\/pico:main/' -i recipe.yml
 
-    - uses: vanilla-os/vib-gh-action@v0.8.1
+    - uses: vanilla-os/vib-gh-action@v1.0.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.5.3'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.6.0'
 
     - uses: actions/upload-artifact@v4
       with:

--- a/modules/00-vanilla-abroot.yml
+++ b/modules/00-vanilla-abroot.yml
@@ -1,25 +1,25 @@
 name: abroot
 type: shell
-source:
-  type: tar
-  url: https://github.com/Vanilla-OS/ABRoot/releases/download/v2.2.0/abrootv2.tar.gz
-  checksum: b87a18e74a19e3cbdfa0ab8631ec9a506daa2da2ba303da320f3d46753de12e7
+sources:
+  - type: tar
+    url: https://github.com/Vanilla-OS/ABRoot/releases/download/v2.2.0/abrootv2.tar.gz
+    checksum: b87a18e74a19e3cbdfa0ab8631ec9a506daa2da2ba303da320f3d46753de12e7
 commands:
   - apt install -y podman golang-github-containers-common patch wget
   - mkdir -p /usr/bin
-  - cp /sources/abroot/abrootv2 /usr/bin/abroot
+  - cp /sources/abroot/abrootv2/abrootv2 /usr/bin/abroot
   - chmod +x /usr/bin/abroot
 modules:
 - name: abroot-manpage
   type: shell
-  source:
-    type: tar
-    url: https://github.com/Vanilla-OS/ABRoot/releases/download/v2.2.0/abroot-man.tar.gz
-    checksum: 572ebd2d9722b5936a003aec86685ed5aeb403efc377b310822bef67a309f2c6
+  sources:
+    - type: tar
+      url: https://github.com/Vanilla-OS/ABRoot/releases/download/v2.2.0/abroot-man.tar.gz
+      checksum: 572ebd2d9722b5936a003aec86685ed5aeb403efc377b310822bef67a309f2c6
   commands:
-  - mv /sources/abroot-manpage/man/man1/abroot.1 /usr/share/man/man1/
+    - mv /sources/abroot-manpage/abroot-man/man/man1/abroot.1 /usr/share/man/man1/
 - name: abroot-deps
   type: apt
-  source:
-    packages:
-      - netavark
+  sources:
+    - packages:
+        - netavark

--- a/modules/00-vanilla-apx-stacks.yml
+++ b/modules/00-vanilla-apx-stacks.yml
@@ -1,10 +1,10 @@
 name: apx-stacks
 type: shell
-source:
-  type: git
-  url: https://github.com/Vanilla-OS/vanilla-apx-configs.git
-  tag: v1.0.0
+sources:
+  - type: git
+    url: https://github.com/Vanilla-OS/vanilla-apx-configs.git
+    tag: v1.0.0
 commands:
 - mkdir -p /usr/share/apx
-- mv /sources/apx-stacks/stacks /usr/share/apx/
-- mv /sources/apx-stacks/package-managers /usr/share/apx/
+- mv /sources/apx-stacks/vanilla-apx-configs/stacks /usr/share/apx/
+- mv /sources/apx-stacks/vanilla-apx-configs/package-managers /usr/share/apx/

--- a/modules/00-vanilla-apx.yml
+++ b/modules/00-vanilla-apx.yml
@@ -1,30 +1,30 @@
 name: apx
 type: shell
-source:
-  type: tar
-  url: https://github.com/Vanilla-OS/apx/releases/download/v2.4.5/apx.tar.gz
-  checksum: 2d4b3145d419810f44a0a7eaea335105662ffe907bac645f9c856421684d2ab9
+sources:
+  - type: tar
+    url: https://github.com/Vanilla-OS/apx/releases/download/v2.4.5/apx.tar.gz
+    checksum: 2d4b3145d419810f44a0a7eaea335105662ffe907bac645f9c856421684d2ab9
 commands:
 - mkdir -p /usr/bin
-- cp /sources/apx/apx /usr/bin/apx
+- cp /sources/apx/apx/apx /usr/bin/apx
 - chmod +x /usr/bin/apx
 modules:
 - name: distrobox
   type: shell
-  source:
-    type: tar
-    url: https://github.com/89luca89/distrobox/archive/refs/tags/1.8.1.2.tar.gz
-    checksum: 3ecbce9b8c5b5df941f986798ffa6ea7fdf742223d42204207974c4323d5b9fc
+  sources:
+    - type: tar
+      url: https://github.com/89luca89/distrobox/archive/refs/tags/1.8.1.2.tar.gz
+      checksum: 3ecbce9b8c5b5df941f986798ffa6ea7fdf742223d42204207974c4323d5b9fc
   commands:
   - mkdir -p /usr/share/apx
-  - cp -r /sources/distrobox/distrobox-1.8.1.2 /usr/share/apx/distrobox
+  - cp -r /sources/distrobox/1.8.1.2/distrobox-1.8.1.2 /usr/share/apx/distrobox
   - chmod +x /usr/share/apx/distrobox/distrobox*
   - sed -E -i 's/.*printf "distrobox.*/echo apx \$(echo ${container_name} | sed "s|apx-||") enter/g' /usr/share/apx/distrobox/distrobox-create
 - name: apx-manpage
   type: shell
-  source:
-    type: tar
-    url: https://github.com/Vanilla-OS/apx/releases/download/v2.4.5/apx-man.tar.gz
-    checksum: 82b3e7b1280e0fe82f7ea33578eda2aa6c1dd1177064cfc48d48e440b0cfdc3b
+  sources:
+    - type: tar
+      url: https://github.com/Vanilla-OS/apx/releases/download/v2.4.5/apx-man.tar.gz
+      checksum: 82b3e7b1280e0fe82f7ea33578eda2aa6c1dd1177064cfc48d48e440b0cfdc3b
   commands:
-  - mv /sources/apx-manpage/man/man1/apx.1 /usr/share/man/man1/
+  - mv /sources/apx-manpage/apx-man/man/man1/apx.1 /usr/share/man/man1/

--- a/modules/00-vanilla-base-files.yml
+++ b/modules/00-vanilla-base-files.yml
@@ -1,17 +1,17 @@
 name: base-files
 type: shell
-source:
-  type: file
-  url: https://github.com/Vanilla-OS/base-files/releases/download/v1.0.0/base-files.deb
-  checksum: f7235c903242c5c8aa5a584c748700da869481e2ea3de6a3a67dfa92c1f25f5d
+sources:
+  - type: file
+    url: https://github.com/Vanilla-OS/base-files/releases/download/v1.0.0/base-files.deb
+    checksum: f7235c903242c5c8aa5a584c748700da869481e2ea3de6a3a67dfa92c1f25f5d
 commands:
-  - dpkg -i /sources/base-files/base-files.deb
+  - dpkg -i /sources/base-files/base-files/base-files.deb
   - apt -y install -f
 modules:
 - name: base-files-deps-install
   type: apt
-  source:
-    packages:
-    - dpkg-dev
-    - build-essential
-    - debhelper
+  sources:
+    - packages:
+      - dpkg-dev
+      - build-essential
+      - debhelper

--- a/modules/01-kernel.yml
+++ b/modules/01-kernel.yml
@@ -1,6 +1,6 @@
 name: kernel
 type: apt
-source:
-  packages:
-  - linux-image-amd64
-  - linux-headers-amd64
+sources:
+  - packages:
+    - linux-image-amd64
+    - linux-headers-amd64

--- a/modules/03-fswarn.yml
+++ b/modules/03-fswarn.yml
@@ -2,8 +2,8 @@ name: fswarn
 type: shell
 commands:
   - mkdir -p /boot/
-  - cp /sources/fswarn/fswarn-x86_64.squash /boot/fswarn.squash
-source:
-  type: tar
-  url: https://github.com/Vanilla-OS/fswarn/releases/download/v1.0-1/fswarn.tar.xz
-  checksum: 52f66710132138c21b81b56cb2d6edc7e59ad6eef4a4065b81af0f852d827dab
+  - cp /sources/fswarn/fswarn/fswarn-x86_64.squash /boot/fswarn.squash
+sources:
+  - type: tar
+    url: https://github.com/Vanilla-OS/fswarn/releases/download/v1.0-1/fswarn.tar.xz
+    checksum: 52f66710132138c21b81b56cb2d6edc7e59ad6eef4a4065b81af0f852d827dab

--- a/modules/05-firmware.yml
+++ b/modules/05-firmware.yml
@@ -1,16 +1,16 @@
 name: firmware
 type: apt
-source:
-  packages:
-  - firmware-linux
-  - firmware-linux-nonfree
-  - firmware-linux-free
-  - firmware-iwlwifi
-  - firmware-realtek
-  - firmware-atheros
-  - intel-microcode
-  - amd64-microcode
-  - b43-fwcutter
-  - firmware-b43-installer
-  - firmware-brcm80211
-  - firmware-sof-signed
+sources:
+  - packages:
+    - firmware-linux
+    - firmware-linux-nonfree
+    - firmware-linux-free
+    - firmware-iwlwifi
+    - firmware-realtek
+    - firmware-atheros
+    - intel-microcode
+    - amd64-microcode
+    - b43-fwcutter
+    - firmware-b43-installer
+    - firmware-brcm80211
+    - firmware-sof-signed

--- a/modules/10-input-and-locale.yml
+++ b/modules/10-input-and-locale.yml
@@ -1,9 +1,9 @@
 name: input-and-locale
 type: apt
-source:
-  packages:
-  - locales
-  - kmod
-  - xkb-data
-  - im-config
-  - console-setup
+sources:
+  - packages:
+    - locales
+    - kmod
+    - xkb-data
+    - im-config
+    - console-setup

--- a/modules/100-modules.yml
+++ b/modules/100-modules.yml
@@ -1,11 +1,11 @@
 name: modules
 type: apt
-source:
-  packages:
-  - dkms
-  - bolt
-  - inputattach
-  - iucode-tool
-  - cryptsetup-initramfs
-  - acpi-call-dkms
-  - libsasl2-modules
+sources:
+  - packages:
+    - dkms
+    - bolt
+    - inputattach
+    - iucode-tool
+    - cryptsetup-initramfs
+    - acpi-call-dkms
+    - libsasl2-modules

--- a/modules/110-fwupd.yml
+++ b/modules/110-fwupd.yml
@@ -1,6 +1,6 @@
 name: fwupd
 type: apt
-source:
-  packages:
-  - fwupd
-  - fwupd-amd64-signed
+sources:
+  - packages:
+    - fwupd
+    - fwupd-amd64-signed

--- a/modules/120-fingerprint.yml
+++ b/modules/120-fingerprint.yml
@@ -1,6 +1,6 @@
 name: fingerprint
 type: apt
-source:
-  packages:
-  - fprintd
-  - libpam-fprintd
+sources:
+  - packages:
+    - fprintd
+    - libpam-fprintd

--- a/modules/140-manpages.yml
+++ b/modules/140-manpages.yml
@@ -1,6 +1,6 @@
 name: manpages
 type: apt
-source:
-  packages:
-  - manpages
-  - manpages-posix
+sources:
+  - packages:
+    - manpages
+    - manpages-posix

--- a/modules/150-init-executable.yml
+++ b/modules/150-init-executable.yml
@@ -5,4 +5,3 @@ commands:
   - mv /usr/sbin/init.new /usr/sbin/init
   - chmod +x /usr/sbin/init
   - chmod +x /usr/share/init.d/*
-

--- a/modules/20-ssh.yml
+++ b/modules/20-ssh.yml
@@ -1,10 +1,10 @@
 name: ssh
 type: apt
-source:
-  packages:
-  - gpg
-  - gpg-agent
-  - dirmngr
-  - ca-certificates
-  - openssh-server
-  - spice-vdagent
+sources:
+  - packages:
+    - gpg
+    - gpg-agent
+    - dirmngr
+    - ca-certificates
+    - openssh-server
+    - spice-vdagent

--- a/modules/30-utils.yml
+++ b/modules/30-utils.yml
@@ -1,14 +1,14 @@
 name: utils
 type: apt
-source:
-  packages:
-  - nano
-  - zsync
-  - rsync
-  - dialog
-  - less
-  - curl
-  - tracker
-  - bash-completion
-  - libnss-myhostname
-  - distrobox
+sources:
+  - packages:
+    - nano
+    - zsync
+    - rsync
+    - dialog
+    - less
+    - curl
+    - tracker
+    - bash-completion
+    - libnss-myhostname
+    - distrobox

--- a/modules/40-essentials.yml
+++ b/modules/40-essentials.yml
@@ -1,27 +1,27 @@
 name: essentials
 type: apt
-source:
-  packages:
-  - setserial
-  - systemd-sysv
-  - user-setup
-  - console-setup
-  - sudo
-  - acpi
-  - polkitd
-  - pkexec
-  - bc
-  - pcmciautils
-  - samba-common-bin
-  - ibus
-  - ibus-table
-  - laptop-detect
-  - efibootmgr
-  - grub-efi-amd64
-  - grub-efi-amd64-bin
-  - grub-efi-amd64-signed
-  - shim-signed
-  - shim-helpers-amd64-signed
-  - uidmap
-  - minisign
-  - zram-tools
+sources:
+  - packages:
+    - setserial
+    - systemd-sysv
+    - user-setup
+    - console-setup
+    - sudo
+    - acpi
+    - polkitd
+    - pkexec
+    - bc
+    - pcmciautils
+    - samba-common-bin
+    - ibus
+    - ibus-table
+    - laptop-detect
+    - efibootmgr
+    - grub-efi-amd64
+    - grub-efi-amd64-bin
+    - grub-efi-amd64-signed
+    - shim-signed
+    - shim-helpers-amd64-signed
+    - uidmap
+    - minisign
+    - zram-tools

--- a/modules/50-fs.yml
+++ b/modules/50-fs.yml
@@ -1,13 +1,13 @@
 name: fs
 type: apt
-source:
-  packages:
-  - exfatprogs
-  - btrfs-progs
-  - dosfstools
-  - gvfs-backends
-  - ntfs-3g
-  - nfs-common
-  - gvfs-fuse
-  - libfuse3-4
-  - lvm2
+sources:
+  - packages:
+    - exfatprogs
+    - btrfs-progs
+    - dosfstools
+    - gvfs-backends
+    - ntfs-3g
+    - nfs-common
+    - gvfs-fuse
+    - libfuse3-4
+    - lvm2

--- a/modules/60-sound.yml
+++ b/modules/60-sound.yml
@@ -1,10 +1,10 @@
 name: sound
 type: apt
-source:
-  packages:
-  - pipewire-pulse
-  - pipewire-alsa
-  - wireplumber
-  - alsa-utils
-  - alsa-firmware-loaders
-  - libasound2t64
+sources:
+  - packages:
+    - pipewire-pulse
+    - pipewire-alsa
+    - wireplumber
+    - alsa-utils
+    - alsa-firmware-loaders
+    - libasound2t64

--- a/modules/70-compression.yml
+++ b/modules/70-compression.yml
@@ -1,7 +1,7 @@
 name: compression
 type: apt
-source:
-  packages:
-  - zstd
-  - zip
-  - unzip
+sources:
+  - packages:
+    - zstd
+    - zip
+    - unzip

--- a/modules/80-xdg.yml
+++ b/modules/80-xdg.yml
@@ -1,7 +1,7 @@
 name: xdg
 type: apt
-source:
-  packages:
-  - xdg-utils
-  - xdg-user-dirs
-  - xdg-user-dirs-gtk
+sources:
+  - packages:
+    - xdg-utils
+    - xdg-user-dirs
+    - xdg-user-dirs-gtk

--- a/modules/90-network.yml
+++ b/modules/90-network.yml
@@ -1,26 +1,26 @@
 name: network
 type: apt
-source:
-  packages:
-  - network-manager
-  - network-manager-config-connectivity-debian
-  - network-manager-openvpn
-  - network-manager-fortisslvpn
-  - network-manager-l2tp
-  - network-manager-openconnect
-  - network-manager-ssh
-  - network-manager-vpnc
-  - modemmanager
-  - wpasupplicant
-  - wireless-tools
-  - wireguard
-  - avahi-autoipd
-  - avahi-daemon
-  - rfkill
-  - bluez
-  - bluez-obexd
-  - libspa-0.2-bluetooth
-  - libnss-mdns
-  - libproxy1-plugin-networkmanager
-  - systemd-timesyncd
-  - iputils-ping
+sources:
+  - packages:
+    - network-manager
+    - network-manager-config-connectivity-debian
+    - network-manager-openvpn
+    - network-manager-fortisslvpn
+    - network-manager-l2tp
+    - network-manager-openconnect
+    - network-manager-ssh
+    - network-manager-vpnc
+    - modemmanager
+    - wpasupplicant
+    - wireless-tools
+    - wireguard
+    - avahi-autoipd
+    - avahi-daemon
+    - rfkill
+    - bluez
+    - bluez-obexd
+    - libspa-0.2-bluetooth
+    - libnss-mdns
+    - libproxy1-plugin-networkmanager
+    - systemd-timesyncd
+    - iputils-ping

--- a/modules/91-iptables.yml
+++ b/modules/91-iptables.yml
@@ -1,8 +1,8 @@
 name: iptables
 type: apt
-source:
-  packages:
-  - iptables
+sources:
+  - packages:
+    - iptables
 modules:
   - name: enable-iptables-systemd-unit
     type: shell

--- a/modules/998-podman-registry.yml
+++ b/modules/998-podman-registry.yml
@@ -3,4 +3,4 @@
 name: podman-rgistry
 type: shell
 commands:
-- echo "unqualified-search-registries=[\"docker.io\"]" >> /etc/containers/registries.conf
+  - echo "unqualified-search-registries=[\"docker.io\"]" >> /etc/containers/registries.conf

--- a/modules/999-remove-grub-files.yml
+++ b/modules/999-remove-grub-files.yml
@@ -1,6 +1,6 @@
 name: remove-grub-files
 type: shell
 commands:
-- rm /etc/grub.d/05_debian_theme
-- rm /etc/grub.d/10_linux
-- rm /etc/grub.d/20_linux_xen
+  - rm /etc/grub.d/05_debian_theme
+  - rm /etc/grub.d/10_linux
+  - rm /etc/grub.d/20_linux_xen

--- a/modules/999-replace-locale-gen.yml
+++ b/modules/999-replace-locale-gen.yml
@@ -1,4 +1,4 @@
 name: replace-locale-gen
 type: shell
 commands:
-- mv /usr/sbin/locale-gen-replacement /usr/sbin/locale-gen
+  - mv /usr/sbin/locale-gen-replacement /usr/sbin/locale-gen

--- a/recipe.yml
+++ b/recipe.yml
@@ -1,9 +1,11 @@
 name: Vanilla Core
 id: core
+vibversion: 1.0.0
 
 stages:
 - id: build
   base: ghcr.io/vanilla-os/pico:dev
+  addincludes: true
   singlelayer: false
   labels:
     maintainer: Vanilla OS Contributors
@@ -60,23 +62,23 @@ stages:
 
   - name: fsguard-runtime-deps
     type: apt
-    source:
-      packages:
-        - "minisign"
-        - "squashfs-tools"
-        - "python3"
+    sources:
+      - packages:
+          - "minisign"
+          - "squashfs-tools"
+          - "python3"
 
   - name: cleanup1
     type: shell
     commands:
-    - apt remove -y dpkg-dev build-essential
-    - apt autoremove -y
-    - apt clean
+      - apt remove -y dpkg-dev build-essential
+      - apt autoremove -y
+      - apt clean
 
   - name: polkit-remember-auth
     type: shell
     commands:
-    - sed -ie 's/auth_admin/auth_admin_keep/' /usr/share/polkit-1/actions/org.freedesktop.policykit.policy
+      - sed -ie 's/auth_admin/auth_admin_keep/' /usr/share/polkit-1/actions/org.freedesktop.policykit.policy
 
   - name: fsguard
     type: fsguard
@@ -86,9 +88,9 @@ stages:
     modules:
       - name: minisign
         type: apt
-        source:
-          packages:
-            - "minisign"
+        sources:
+          - packages:
+              - "minisign"
 
   - name: cleanup2
     type: shell


### PR DESCRIPTION
This PR builds upon https://github.com/Vanilla-OS/core-image/pull/100 to achieve full Vib 1.0 compatibility. It requires the following binaries to work properly:
- [Vib 1.0.2](https://github.com/Vanilla-OS/Vib/releases/tag/v1.0.2)
- The latest `fsguard.so` from Vanilla-OS/vib-fsguard#14