### PR TITLE
feature [closes #120]: adds libfuse 2

### DIFF
--- a/modules/50-fs.yml
+++ b/modules/50-fs.yml
@@ -10,4 +10,5 @@ sources:
     - nfs-common
     - gvfs-fuse
     - libfuse3-4
+    - libfuse2t64
     - lvm2


### PR DESCRIPTION
This is required for AppImage.

See #120 for details.

Closes #120 