### PR TITLE
improves migration script

### DIFF
--- a/includes.container/usr/share/initramfs-tools/scripts/local-bottom/vanilla-filesystem-upgrade
+++ b/includes.container/usr/share/initramfs-tools/scripts/local-bottom/vanilla-filesystem-upgrade
@@ -17,7 +17,11 @@ esac
 mount -o remount,rw ${rootmnt}
 if [ -d ${rootmnt}/.system ]; then
 	echo "vanilla-filesystem-upgrade: Detected old filesystem at /.system, upgrading..."
-	rm -f ${rootmnt}/etc ${rootmnt}/usr
+
+	set -e
+
+	rm -f ${rootmnt}/etc ${rootmnt}/usr ${rootmnt}/bin ${rootmnt}/lib ${rootmnt}/lib64 ${rootmnt}/sbin ${rootmnt}/vanilla.key
+	rm -rf ${rootmnt}/FsGuard ${rootmnt}/sysconf
 	mv ${rootmnt}/.system/FsGuard ${rootmnt}/.system/etc ${rootmnt}/.system/sysconf ${rootmnt}/.system/usr ${rootmnt}/.system/bin ${rootmnt}/.system/lib ${rootmnt}/.system/lib64 ${rootmnt}/.system/sbin ${rootmnt}/.system/vanilla.key ${rootmnt}
 	rm -rf ${rootmnt}/.system
 	echo "vanilla-filesystem-upgrade: Filesystem upgrade completed"


### PR DESCRIPTION
This is necessary to make rolling back and then upgrading again possible for this upgrade.

It also exits on an error to prevent an inconsistent system state.