### PR TITLE
feat: clean up packages

### DIFF
--- a/modules/00-vanilla-abroot.yml
+++ b/modules/00-vanilla-abroot.yml
@@ -10,7 +10,6 @@ sources:
     checksum: 9e3226d1132d94a914a2f478aabe3a9ec7bfa692b88ff30391827888b9927ba1
     only-arches: [arm64]
 commands:
-  - apt install -y podman golang-github-containers-common patch wget
   - mkdir -p /usr/bin
   - cp /sources/abroot/abrootv2*/abrootv2 /usr/bin/abroot
   - chmod +x /usr/bin/abroot

--- a/modules/00-vanilla-base-files.yml
+++ b/modules/00-vanilla-base-files.yml
@@ -5,13 +5,4 @@ sources:
     url: https://github.com/Vanilla-OS/base-files/releases/download/v1.0.1/base-files.deb
     checksum: e5a541ad1a85d922475eda2eb2cd8b6620e1aa36698dc99b7a36262435c25df1
 commands:
-  - dpkg -i /sources/base-files/base-files/base-files.deb
-  - apt -y install -f
-modules:
-- name: base-files-deps-install
-  type: apt
-  sources:
-    - packages:
-      - dpkg-dev
-      - build-essential
-      - debhelper
+  - apt install -y /sources/base-files/base-files/base-files.deb

--- a/modules/05-firmware.yml
+++ b/modules/05-firmware.yml
@@ -3,12 +3,9 @@ type: apt
 sources:
   - packages:
     - firmware-linux
-    - firmware-linux-nonfree
-    - firmware-linux-free
     - firmware-iwlwifi
     - firmware-realtek
     - firmware-atheros
-    - b43-fwcutter
     - firmware-b43-installer
     - firmware-brcm80211
     - firmware-sof-signed

--- a/modules/10-input-and-locale.yml
+++ b/modules/10-input-and-locale.yml
@@ -3,7 +3,6 @@ type: apt
 sources:
   - packages:
     - locales
-    - kmod
-    - xkb-data
+    - ibus-table
     - im-config
     - console-setup

--- a/modules/100-modules.yml
+++ b/modules/100-modules.yml
@@ -8,6 +8,3 @@ sources:
     - cryptsetup-initramfs
     - acpi-call-dkms
     - libsasl2-modules
-  - packages:
-    - iucode-tool
-    only-arches: [amd64]

--- a/modules/110-fwupd.yml
+++ b/modules/110-fwupd.yml
@@ -3,9 +3,4 @@ type: apt
 sources:
   - packages:
     - fwupd
-  - packages:
-    - fwupd-amd64-signed
-    only-arches: [amd64]
-  - packages:
-    - fwupd-arm64-signed
-    only-arches: [arm64]
+    - fwupd-signed

--- a/modules/120-fingerprint.yml
+++ b/modules/120-fingerprint.yml
@@ -2,5 +2,4 @@ name: fingerprint
 type: apt
 sources:
   - packages:
-    - fprintd
     - libpam-fprintd

--- a/modules/20-ssh.yml
+++ b/modules/20-ssh.yml
@@ -2,9 +2,5 @@ name: ssh
 type: apt
 sources:
   - packages:
-    - gpg
-    - gpg-agent
-    - dirmngr
-    - ca-certificates
     - openssh-server
     - spice-vdagent

--- a/modules/20-ssh.yml
+++ b/modules/20-ssh.yml
@@ -3,4 +3,3 @@ type: apt
 sources:
   - packages:
     - openssh-server
-    - spice-vdagent

--- a/modules/30-utils.yml
+++ b/modules/30-utils.yml
@@ -8,7 +8,7 @@ sources:
     - dialog
     - less
     - curl
-    - tracker
+    - tinysparql
     - bash-completion
     - libnss-myhostname
     - distrobox

--- a/modules/40-essentials.yml
+++ b/modules/40-essentials.yml
@@ -3,33 +3,23 @@ type: apt
 sources:
   - packages:
     - setserial
-    - systemd-sysv
     - user-setup
     - console-setup
     - sudo
     - acpi
-    - polkitd
     - pkexec
     - bc
     - pcmciautils
     - samba-common-bin
-    - ibus
-    - ibus-table
     - laptop-detect
     - efibootmgr
     - shim-signed
-    - uidmap
     - minisign
     - zram-tools
+    - grub-efi
   - packages:
-    - grub-efi-amd64
-    - grub-efi-amd64-bin
     - grub-efi-amd64-signed
-    - shim-helpers-amd64-signed
     only-arches: [amd64]
   - packages:
-    - grub-efi-arm64
-    - grub-efi-arm64-bin
     - grub-efi-arm64-signed
-    - shim-helpers-arm64-signed
     only-arches: [arm64]

--- a/modules/41-move-boot-scripts.yml
+++ b/modules/41-move-boot-scripts.yml
@@ -8,4 +8,3 @@ commands:
   - mv /usr/sbin/update-grub /usr/libexec/
   - mv /usr/sbin/update-grub-replacement /usr/sbin/update-grub
   - chmod +x /usr/sbin/update-grub
-  

--- a/modules/45-lvm-fix.yml
+++ b/modules/45-lvm-fix.yml
@@ -3,4 +3,3 @@ type: shell
 commands:
   - chmod +x /usr/share/initramfs-tools/hooks/vanilla-lvm-fix
   - chmod +x /usr/share/initramfs-tools/scripts/init-premount/vanilla-lvm-fix
-  

--- a/modules/50-fs.yml
+++ b/modules/50-fs.yml
@@ -9,6 +9,5 @@ sources:
     - ntfs-3g
     - nfs-common
     - gvfs-fuse
-    - libfuse3-4
     - libfuse2t64
     - lvm2

--- a/modules/60-sound.yml
+++ b/modules/60-sound.yml
@@ -7,4 +7,3 @@ sources:
     - wireplumber
     - alsa-utils
     - alsa-firmware-loaders
-    - libasound2t64

--- a/modules/80-xdg.yml
+++ b/modules/80-xdg.yml
@@ -1,7 +1,0 @@
-name: xdg
-type: apt
-sources:
-  - packages:
-    - xdg-utils
-    - xdg-user-dirs
-    - xdg-user-dirs-gtk

--- a/modules/90-network.yml
+++ b/modules/90-network.yml
@@ -2,7 +2,6 @@ name: network
 type: apt
 sources:
   - packages:
-    - network-manager
     - network-manager-config-connectivity-debian
     - network-manager-openvpn
     - network-manager-fortisslvpn

--- a/modules/998-podman-registry.yml
+++ b/modules/998-podman-registry.yml
@@ -1,6 +1,6 @@
 # this module exists to work around dpkg failing to install a podman
 # dependency, due to a conflict with our existing registry configuration
-name: podman-rgistry
+name: podman-registry
 type: shell
 commands:
   - echo "unqualified-search-registries=[\"docker.io\"]" >> /etc/containers/registries.conf

--- a/recipe.yml
+++ b/recipe.yml
@@ -44,7 +44,6 @@ stages:
       - modules/50-fs.yml
       - modules/60-sound.yml
       - modules/70-compression.yml
-      - modules/80-xdg.yml
       - modules/90-network.yml
       - modules/91-iptables.yml
       - modules/100-modules.yml


### PR DESCRIPTION
This PR optimizes the packages by:
1. Removing redundant packages that are already included as dependencies to simplify the recipe.
2. Removing desktop-related packages, as these should be managed in `desktop-image`.
3. ~Removing Apx, which can now be installed via Flatpak (Vanilla-OS/first-setup#406).~