### PR TITLE
fix: keep initramfs-tools

### DIFF
--- a/modules/01-kernel.yml
+++ b/modules/01-kernel.yml
@@ -9,5 +9,7 @@ sources:
     - linux-image-arm64
     - linux-headers-arm64
     only-arches: [arm64]
+  - packages:
+    - initramfs-tools
 cleanup:
   - /etc/machine-id


### PR DESCRIPTION
Works around #145.

Since the current version of ABRoot does not support dracut, we must continue using initramfs-tools for now in order to maintain backward compatibility.