### PR TITLE
fix: install intel, mediatek, and nvidia firmware again

### DIFF
--- a/modules/05-firmware.yml
+++ b/modules/05-firmware.yml
@@ -9,6 +9,10 @@ sources:
     - firmware-b43-installer
     - firmware-brcm80211
     - firmware-sof-signed
+    - firmware-intel-graphics
+    - firmware-intel-misc
+    - firmware-mediatek
+    - firmware-nvidia-graphics
   - packages:
     - intel-microcode
     - amd64-microcode


### PR DESCRIPTION
The relevant packages have been demoted to "suggested" to fix https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1137651 and therefore are not installed by default anymore.

---

Not tested.